### PR TITLE
Add Git config suggested by GitButler blog

### DIFF
--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -6,3 +6,5 @@
 	templatedir = ~/.git-templates
 [rerere]
 	enabled = true
+[branch]
+	sort = -committerdate

--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -4,3 +4,5 @@
 	signingkey = B925D752A6E402AF
 [init]
 	templatedir = ~/.git-templates
+[rerere]
+	enabled = true


### PR DESCRIPTION
Couldn't activate signing with SSH yet, because CentOS 7 uses a very old version of OpenSSH, which isn't supported for signing.