### PR TITLE
Configure Git to push a renamed branch to a new remote branch with th…

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -8,3 +8,5 @@
 	enabled = true
 [branch]
 	sort = -committerdate
+[push]
+	default = current


### PR DESCRIPTION
…e updated name

[This article] has a nice overview of the push actions, which is more understandable than the help page. A summary:

- `upstream` would push to the already set upstream branch (i.e. the old name)
- `simple` would push to an upstream branch with the same name, but only if it already exists
- `current` would push to an upstream branch with the same name, but would also create it if it doesn't already exist

[This article]: https://rakhesh.com/coding/git-push-default/