### PR TITLE
Fix tab completion of variables

### DIFF
--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -1,5 +1,11 @@
 source ~/.bashrc.d/.skel.bashrc
 
+# Fix tab completion of variables
+_minimal() {
+    [[ $2 == "$"* ]] || compopt -o filenames
+    compopt -o bashdefault -o default
+}
+
 eval "$(starship init bash)"
 eval "$(direnv hook bash)"
 


### PR DESCRIPTION
The `bash-completions` package busts tab completion of commands that contain variables as args. For example `cd $HOME<TAB>` would not work properly. The exact reasons are sort of described [here].

[here]: https://github.com/scop/bash-completion/issues/444