### PR TITLE
Improve work with stacked branches w.r.t. rebasing

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -14,3 +14,5 @@
 	prune = true
 [alias]
 	root = rev-parse --show-toplevel
+[rebase]
+    updateRefs = true


### PR DESCRIPTION
Given a stack of branches, A, B and C, when rebasing C with `--update-refs`, this will also rebase A and B. This article provides a nice writeup: https://andrewlock.net/working-with-stacked-branches-in-git-is-easier-with-update-refs/.