### PR TITLE
Separate downloading and commiting when doing `git pull`

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -16,3 +16,5 @@
 	root = rev-parse --show-toplevel
 [rebase]
     updateRefs = true
+[pull]
+    ff = only


### PR DESCRIPTION
If there are any changes on the branch being pulled, Git will fail. The user can explicitly choose what to do (e.g. rebase). Git will not try to create any commit while pulling.